### PR TITLE
Fixed confusing prompt

### DIFF
--- a/virtualhost.sh
+++ b/virtualhost.sh
@@ -752,7 +752,7 @@ case $resp in
   n*|N*)
     while : ; do
       if [ -z "$FOLDER" ]; then
-        /bin/echo -n "  - Enter new folder name (located in Sites): "
+        /bin/echo -n "  - Enter new folder name (located in $DOC_ROOT_PREFIX): "
         read FOLDER
       else
         break


### PR DESCRIPTION
Prompting "Sites" was confusing as it indicated changes to
$DOC_ROOT_PREFIX hadn't taken effect. I've changed to reflect this (and
a give a reminder what the document root is set to)
