### PR TITLE
added document root path to custom folder name

### DIFF
--- a/virtualhost.sh
+++ b/virtualhost.sh
@@ -865,7 +865,8 @@ if [ -z "$FOLDER" ]; then
       while : ; do
         if [ -z "$FOLDER" ]; then
           /bin/echo -n "  - Enter new folder name (located in $DOC_ROOT_PREFIX): "
-          read FOLDER
+          read response
+          FOLDER=$DOC_ROOT_PREFIX/$response
         else
           break
         fi


### PR DESCRIPTION
when giving a custom folder name, the document root prefix was not being included as part of the folder path.. i was previously getting virtualhost files that looked like this:
```
<VirtualHost *:80>
  DocumentRoot "website.com"
  ServerName website.dev
  #ServerAlias your.alias.here

  ScriptAlias /cgi-bin "website.com/cgi-bin"

  <Directory "website.com">
    Options All
    AllowOverride All
    Require all granted
  </Directory>

  #CustomLog "" combined
  #ErrorLog ""

</VirtualHost>
```

and now they look like this:

```
<VirtualHost *:80>
  DocumentRoot "/Users/user/Sites/website.com"
  ServerName website.dev

  ScriptAlias /cgi-bin "/Users/user/Sites/website.com/cgi-bin"

  <Directory "/Users/user/Sites/website.com">
    Options All
    AllowOverride All
    Require all granted
  </Directory>

  #CustomLog "" combined
  #ErrorLog ""

</VirtualHost>
```